### PR TITLE
Refactor: Convert plugins to ES Modules and fix runtime errors

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,6 +14,8 @@ for (const file of fs.readdirSync(pluginsDir)) {
   }
 }
 
+global.botEnabled = true;
+
 async function startBot() {
   console.log('Iniciando conexión con WhatsApp...')
 
@@ -47,6 +49,18 @@ async function startBot() {
       // Buscar plugin cuyo nombre coincida con el mensaje
       const plugin = plugins.get(text)
       if (plugin) {
+        // Check if bot is disabled
+        if (!global.botEnabled && !plugin.owner) {
+          return;
+        }
+
+        // A simple owner check
+        const ownerJid = 'your_jid_here@s.whatsapp.net'; // TODO: Make this configurable
+        if (plugin.owner && msg.key.remoteJid !== ownerJid) {
+            await sock.sendMessage(msg.key.remoteJid, { text: 'Este comando es solo para el propietario del bot.' });
+            return;
+        }
+
         try {
           await plugin.execute(sock, msg, [])
         } catch (err) {

--- a/plugins/code.js
+++ b/plugins/code.js
@@ -1,25 +1,31 @@
-module.exports = {
+export default {
   name: 'code',
-  pattern: /^code\s*(\+\d+)?$/i,
-  description: 'Genera un código de vinculación para un subbot (enviado a tu chat privado)',
-  async run({ sock, msg, jid, text, sender, connectBot, subBots }) {
-    const phoneNumber = text.match(/\+\d{6,}/)?.[0];
+  description: 'Genera un código de vinculación para un subbot (actualmente deshabilitado)',
+  execute: async (sock, msg, args) => {
+    const jid = msg.key.remoteJid;
+    await sock.sendMessage(jid, {
+      text: 'Lo siento, la función de crear sub-bots está actualmente deshabilitada.'
+    });
+    // const text = msg.message.conversation;
+    // const sender = msg.key.participant || msg.key.remoteJid;
+    // const phoneNumber = text.match(/\+\d{6,}/)?.[0];
 
-    if (!phoneNumber) {
-      await sock.sendMessage(jid, {
-        text: 'Por favor, proporciona un número de teléfono. Ejemplo: code +50412345678'
-      });
-      return;
-    }
+    // if (!phoneNumber) {
+    //   await sock.sendMessage(jid, {
+    //     text: 'Por favor, proporciona un número de teléfono. Ejemplo: code +50412345678'
+    //   });
+    //   return;
+    // }
 
-    if (Object.keys(subBots).length >= 30) {
-      await sock.sendMessage(jid, {
-        text: 'Se alcanzó el límite de subbots (30). Elimina uno antes de agregar otro.'
-      });
-      return;
-    }
+    // console.log('La función de sub-bots no está implementada en main.js');
+    // if (Object.keys(subBots).length >= 30) {
+    //   await sock.sendMessage(jid, {
+    //     text: 'Se alcanzó el límite de subbots (30). Elimina uno antes de agregar otro.'
+    //   });
+    //   return;
+    // }
 
-    const botName = `SUBBOT_${Date.now()}`;
-    subBots[botName] = await connectBot(phoneNumber, true, botName, msg, sender);
+    // const botName = `SUBBOT_${Date.now()}`;
+    // subBots[botName] = await connectBot(phoneNumber, true, botName, msg, sender);
   }
 };

--- a/plugins/disable.js
+++ b/plugins/disable.js
@@ -1,11 +1,12 @@
 // plugins/disable.js
-module.exports = {
+export default {
   name: 'disable',
-  pattern: /^disable$/i,
   owner: true,
   description: 'Desactiva el bot para usuarios no privilegiados',
-  async run({ sock, msg, jid }) {
-    botEnabled = false;
-    await sock.sendMessage(jid, { text: `${BOT_NAME} desactivado.` });
+  execute: async (sock, msg, args) => {
+    const jid = msg.key.remoteJid;
+    // This assumes botEnabled is a global variable managed in main.js
+    global.botEnabled = false;
+    await sock.sendMessage(jid, { text: `Bot desactivado.` });
   },
 };

--- a/plugins/enable.js
+++ b/plugins/enable.js
@@ -1,11 +1,12 @@
 // plugins/enable.js
-module.exports = {
+export default {
   name: 'enable',
-  pattern: /^enable$/i,
   owner: true,
   description: 'Activa el bot para todos los usuarios',
-  async run({ sock, msg, jid }) {
-    botEnabled = true;
-    await sock.sendMessage(jid, { text: `${BOT_NAME} activado.` });
+  execute: async (sock, msg, args) => {
+    const jid = msg.key.remoteJid;
+    // This assumes botEnabled is a global variable managed in main.js
+    global.botEnabled = true;
+    await sock.sendMessage(jid, { text: `Bot activado.` });
   },
 };

--- a/plugins/lid.js
+++ b/plugins/lid.js
@@ -1,10 +1,15 @@
 // plugins/lid.js
-module.exports = {
+export default {
   name: 'lid',
-  pattern: /^lid$/i,
   description: 'Muestra el número de teléfono del remitente y mencionados',
-  async run({ sock, msg, jid, sender, mentionedJids, getPhoneNumber }) {
-    let response = `🔍 *Números detectados por ${BOT_NAME}*\n\n`;
+  execute: async (sock, msg, args) => {
+    const jid = msg.key.remoteJid;
+    const sender = msg.key.participant || msg.key.remoteJid;
+    const mentionedJids = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid || [];
+
+    const getPhoneNumber = (jid) => jid.split('@')[0];
+
+    let response = `🔍 *Números detectados*\n\n`;
     response += `👤 Remitente: ${getPhoneNumber(sender)}\n`;
     if (mentionedJids.length > 0) {
       response += `📌 Mencionados:\n${mentionedJids.map(j => ` - ${getPhoneNumber(j)}`).join('\n')}`;

--- a/plugins/update.js
+++ b/plugins/update.js
@@ -1,16 +1,16 @@
 // plugins/update.js
-const { exec } = require('child_process');
-const util = require('util');
+import { exec } from 'child_process';
+import util from 'util';
 const execPromise = util.promisify(exec);
 
-module.exports = {
+export default {
   name: 'update',
-  pattern: /^update$/i,
   owner: true,
   description: 'Actualiza el bot desde GitHub',
-  async run({ sock, msg, jid }) {
+  execute: async (sock, msg, args) => {
+    const jid = msg.key.remoteJid;
     try {
-      await sock.sendMessage(jid, { text: `Actualizando ${BOT_NAME} desde GitHub...` });
+      await sock.sendMessage(jid, { text: `Actualizando bot desde GitHub...` });
       await execPromise('git pull origin main');
       await sock.sendMessage(jid, { text: 'Bot actualizado. Reinicia para aplicar cambios.' });
     } catch (err) {


### PR DESCRIPTION
- Converted all plugins from CommonJS (`module.exports`) to ES Modules (`export default`) to resolve `ReferenceError: module is not defined`.
- Standardized the plugin execution signature to `execute(sock, msg, args)`.
- Updated `main.js` to correctly load and execute the refactored plugins.
- Added handling for `owner`-only commands and an enable/disable flag for the bot.
- Disabled the non-functional `code` plugin and refactored other plugins to work with the new structure.